### PR TITLE
Adding the ability to stop feed reading intervals.

### DIFF
--- a/danielqiu:feed.js
+++ b/danielqiu:feed.js
@@ -56,6 +56,7 @@ Feed.read = function() {
         var refresh_interval = feed.refresh_interval || 10000 ;
 
         var intervalId = Meteor.setInterval(function() {
+
             feed.latest_date = null;
 
             if (feed.type === FeedType.TWITTER) {
@@ -67,13 +68,15 @@ Feed.read = function() {
 
         refreshIntervalIds[feed._id] = intervalId;
 
-    })
+    });
+
 };
 
 Feed.stopReading = function() {
     if (!_.isEmpty(refreshIntervalIds)) {
         _.each(_.values(refreshIntervalIds), function(intervalId) {
-          Meteor.clearInterval(intervalId);
+            Meteor.clearInterval(intervalId);
         });
+        console.log("Stopped " + _.keys(refreshIntervalIds).length + " feeds");
     }
 };

--- a/feed-reader/fetchFeedAtom.js
+++ b/feed-reader/fetchFeedAtom.js
@@ -37,7 +37,8 @@ fetchAtomRss = function (feed) {
         // This is where the action is!
         var stream = this,
             meta = this.meta, // **NOTE** the "meta" is always available in the context of the feedparser instance
-            item = '';
+            item;
+
         while (item = this.read()) {
             processFeed(item, feed);
         }

--- a/feed-reader/fetchFeedAtom.js
+++ b/feed-reader/fetchFeedAtom.js
@@ -9,8 +9,6 @@ fetchAtomRss = function (feed) {
     var req = request(feed.link),
     feedparser = new Feedparser();
 
-    //req.setMaxListeners(0);
-
     req.on('error', function (error) {
         // handle any request errors
         console.log("req error: " + error);

--- a/feed-reader/fetchFeedAtom.js
+++ b/feed-reader/fetchFeedAtom.js
@@ -9,6 +9,8 @@ fetchAtomRss = function (feed) {
     var req = request(feed.link),
     feedparser = new Feedparser();
 
+    //req.setMaxListeners(0);
+
     req.on('error', function (error) {
         // handle any request errors
         console.log("req error: " + error);
@@ -37,10 +39,10 @@ fetchAtomRss = function (feed) {
         // This is where the action is!
         var stream = this,
             meta = this.meta, // **NOTE** the "meta" is always available in the context of the feedparser instance
-            item;
-
+            item = '';
         while (item = this.read()) {
             processFeed(item, feed);
         }
+
     });
 }

--- a/feed-reader/saveFeed.js
+++ b/feed-reader/saveFeed.js
@@ -11,7 +11,7 @@ insertFeedEntry = function (entry, feed) {
 
     // store the latest feed date
     console.log("typeof feed.latest_date: " + typeof feed.latest_date);
-    console.log("feed.latest_date: " + feed.latest_date)
+    console.log("feed.latest_date: " + feed.latest_date);
     if (typeof feed.latest_date === 'undefined' || feed.latest_date == null
         || feed.latest_date < entry.pubdate) {
 
@@ -28,5 +28,6 @@ insertFeedEntry = function (entry, feed) {
 
         //update in-memory variable of feed
         feed.last_updated = entry.pubdate;
+
     }
 }

--- a/test/danielqiu:feed-tests.js
+++ b/test/danielqiu:feed-tests.js
@@ -1,7 +1,9 @@
-Tinytest.add('Feed - Test github Feed fetching', function (test) {
-	
-	var Feeds = new Meteor.Collection("feeds_test");
-	var FeedEntries = new Meteor.Collection("feed_entries_test");
+Tinytest.add(
+	'Feed - Test github Feed fetching and cancelling',
+	function (test) {
+
+		var Feeds = new Meteor.Collection("feeds_test");
+		var FeedEntries = new Meteor.Collection("feed_entries_test");
 
     var collections = {
         feeds: Feeds,
@@ -23,10 +25,33 @@ Tinytest.add('Feed - Test github Feed fetching', function (test) {
     Feed.read();
 
     var feed_created = Feeds.find();
-
     test.isNotNull(feed_created, "feed wasn't created");
 
     var feed_entries_created = FeedEntries.find();
-
     test.isNotNull(feed_entries_created, "feed entries weren't created");
+
+		test.isFalse(
+				_.isEmpty(Feed.refreshIntervalHandles),
+				"Feed refresh interval handles should exist"
+		);
+
+		var clearIntervalCount = 0;
+		Meteor.clearInterval = function () {
+				clearIntervalCount += 1;
+		};
+
+		test.equal(
+				clearIntervalCount,
+				0,
+				"clearInterval should not have been called yet"
+		);
+
+		Feed.stopReading();
+
+		test.equal(clearIntervalCount, 1, "clearInterval should have been called");
+		test.isTrue(
+				_.isEmpty(Feed.refreshIntervalHandles),
+				"Feed refresh interval handles should not exist"
+		);
+
 });

--- a/test/danielqiu:feed-tests.js
+++ b/test/danielqiu:feed-tests.js
@@ -1,9 +1,9 @@
 Tinytest.add(
-	'Feed - Test github Feed fetching and cancelling',
-	function (test) {
+  'Feed - Test github Feed fetching and cancelling',
+  function (test) {
 
-		var Feeds = new Meteor.Collection("feeds_test");
-		var FeedEntries = new Meteor.Collection("feed_entries_test");
+    var Feeds = new Meteor.Collection("feeds_test");
+    var FeedEntries = new Meteor.Collection("feed_entries_test");
 
     var collections = {
         feeds: Feeds,
@@ -30,28 +30,28 @@ Tinytest.add(
     var feed_entries_created = FeedEntries.find();
     test.isNotNull(feed_entries_created, "feed entries weren't created");
 
-		test.isFalse(
-				_.isEmpty(Feed.refreshIntervalHandles),
-				"Feed refresh interval handles should exist"
-		);
+    test.isFalse(
+        _.isEmpty(Feed.refreshIntervalHandles),
+        "Feed refresh interval handles should exist"
+    );
 
-		var clearIntervalCount = 0;
-		Meteor.clearInterval = function () {
-				clearIntervalCount += 1;
-		};
+    var clearIntervalCount = 0;
+    Meteor.clearInterval = function () {
+        clearIntervalCount += 1;
+    };
 
-		test.equal(
-				clearIntervalCount,
-				0,
-				"clearInterval should not have been called yet"
-		);
+    test.equal(
+        clearIntervalCount,
+        0,
+        "clearInterval should not have been called yet"
+    );
 
-		Feed.stopReading();
+    Feed.stopReading();
 
-		test.equal(clearIntervalCount, 1, "clearInterval should have been called");
-		test.isTrue(
-				_.isEmpty(Feed.refreshIntervalHandles),
-				"Feed refresh interval handles should not exist"
-		);
+    test.equal(clearIntervalCount, 1, "clearInterval should have been called");
+    test.isTrue(
+        _.isEmpty(Feed.refreshIntervalHandles),
+        "Feed refresh interval handles should not exist"
+    );
 
 });


### PR DESCRIPTION
Hi - I've been using your package and came across the need to be able to stop all feed reading intervals. I forked and modified the code a bit to add a Feed.stopReading function (that's leveraging the returned interval handles from Meteor.setInterval). I also adjusted Feed.read to fetch all new feed entries on first call right away, then wait for the desired interval before firing again. Here's the code if you're interested. Thanks for the package!
